### PR TITLE
Improve email layout

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,7 +40,7 @@ Vagrant.configure(2) do |config|
   # information on available options.
 
   # Set synced folder permissions
-  config.vm.synced_folder "./", "/vagrant", :mount_options => [ "dmode=755,fmode=755," ], owner: 33, group: 33
+  config.vm.synced_folder "./", "/vagrant", owner: 33, group: 33
 
   # This provisioner runs on the first `vagrant up`.
   config.vm.provision "install", type: "shell", inline: <<-SHELL

--- a/api.raml
+++ b/api.raml
@@ -35,9 +35,11 @@ types:
     html_body:
       requiredIfNot: [text_body]
     attempts_count: integer
-    updated_at: integer
+    updated_at:
+      type: integer
       description: UTC epoch
-    created_at: integer
+    created_at:
+      type: integer
       description: UTC epoch
     error:
 
@@ -69,7 +71,7 @@ types:
         {
           "to_address": "to@example.org",
           "subject": "HTML and text",
-          "text_body": "Email content"
+          "text_body": "Email content",
           "html_body": "<p>Email content</p>"
         }
     responses:
@@ -77,7 +79,8 @@ types:
         body: NewEmailCreated
       401:
         description: The request was either missing the Authorization header or used an invalid token
-        body: Error
+        body:
+          type: Error
           example: |
             {
               "name": "Unauthorized",
@@ -87,7 +90,8 @@ types:
             }
       422:
         description: The request data does not satisfy some validation rule.
-        body: Error
+        body:
+          type: Error
           example: |
             {
               "name": "Unprocessable entity",
@@ -97,7 +101,8 @@ types:
             }
       500:
         description: A server-side error occurred.
-        body: Error
+        body:
+          type: Error
           example: |
             {
               "name": "Internal Server Error",

--- a/application/common/mail/layouts/html.php
+++ b/application/common/mail/layouts/html.php
@@ -14,24 +14,24 @@ use Sil\PhpEnv\Env;
     $maxWidth = Env::get('EMAIL_MAX_WIDTH', '600px');
     ?>
     <div style="padding: 25px 15px;">
-      <div style="margin-left: auto; margin-right: auto; max-width: <?= $maxWidth ?>;">
-    <header>
-        <table style="background-color: <?= $brandColor ?>; width: 100%">
-            <tr>
-                <td>
-                    <img src="<?= $logo ?>" style="max-height: 4em; vertical-align: middle">
-                </td>
-            </tr>
-        </table>
-    </header>
+        <div style="margin-left: auto; margin-right: auto; max-width: <?= $maxWidth ?>;">
+            <header>
+                <table style="background-color: <?= $brandColor ?>; width: 100%">
+                    <tr>
+                        <td>
+                            <img src="<?= $logo ?>" style="max-height: 4em; vertical-align: middle">
+                        </td>
+                    </tr>
+                </table>
+            </header>
 
-    <div style="border-bottom: 1px solid #d3d3d3; padding: 10px;">
-        <?php
-        /* @var $content string email contents */
-        ?>
-        <?= $content ?>
-    </div>
-      </div>
+            <div style="border-bottom: 1px solid #d3d3d3; padding: 10px;">
+                <?php
+                /* @var $content string email contents */
+                ?>
+                <?= $content ?>
+            </div>
+        </div>
     </div>
 </body>
 </html>

--- a/application/common/mail/layouts/html.php
+++ b/application/common/mail/layouts/html.php
@@ -1,5 +1,6 @@
 <?php
 use Sil\PhpEnv\Env;
+
 ?>
 <!DOCTYPE html>
 <html>
@@ -10,7 +11,10 @@ use Sil\PhpEnv\Env;
     <?php
     $brandColor = Env::get('EMAIL_BRAND_COLOR', '');
     $logo = Env::get('EMAIL_BRAND_LOGO', '');
+    $maxWidth = Env::get('EMAIL_MAX_WIDTH', '600px');
     ?>
+    <div style="padding: 25px 15px;">
+      <div style="margin-left: auto; margin-right: auto; max-width: <?= $maxWidth ?>;">
     <header>
         <table style="background-color: <?= $brandColor ?>; width: 100%">
             <tr>
@@ -21,11 +25,13 @@ use Sil\PhpEnv\Env;
         </table>
     </header>
 
-    <main>
+    <div style="border-bottom: 1px solid #d3d3d3; padding: 10px;">
         <?php
         /* @var $content string email contents */
         ?>
         <?= $content ?>
-    </main>
+    </div>
+      </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
This is primarily to constrain email content to centered 600px. This seems to be a common practice in nicely formatted emails these days.

There are also a couple other small fixes in this PR.