### PR TITLE
Release 1.12.1 -- remove config-shim to use the version in the silintl/php8 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,6 @@ COPY dockerbuild/vhost.conf /etc/apache2/sites-enabled/
 # ErrorLog inside a VirtualHost block is ineffective for unknown reasons
 RUN sed -i -E 's@ErrorLog .*@ErrorLog /proc/self/fd/2@i' /etc/apache2/apache2.conf
 
-ADD https://github.com/silinternational/config-shim/releases/download/v1.2.0/config-shim.gz config-shim.gz
-RUN gzip -d config-shim.gz && chmod 755 config-shim && mv config-shim /usr/local/bin
-
 EXPOSE 80
 
 CMD ["/data/run.sh"]


### PR DESCRIPTION
### Removed
- Removed config-shim from Dockerfile to use the version in the silintl/php8 base image


### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] ~Documentation (README, etc.)~
- [x] ~Unit tests created or updated~
- [x] ~Run `make composershow`~
